### PR TITLE
Public setters for serializable X and Y props in Point2D.

### DIFF
--- a/src/Point2D.cs
+++ b/src/Point2D.cs
@@ -21,10 +21,10 @@ namespace NP.Utilities
         where T : IComparable<T>
     {
         [XmlAttribute]
-        public T X { get; }
+        public T X { get; set; }
 
         [XmlAttribute]
-        public T Y { get; }
+        public T Y { get; set; }
 
         public Point2D()
         {


### PR DESCRIPTION
There is a problem in UniDock at the moment. The position and size of floating windows are not saved and restored. The reason for this is the lack of public setters for the X and Y coordinates in the Point2D class. Which makes it impossible to serialize and deserialize them into XML format. This PR is intended to fix it.